### PR TITLE
Update aws-sdk call for 2.x.

### DIFF
--- a/recipes/simpledbconfig.rb
+++ b/recipes/simpledbconfig.rb
@@ -44,7 +44,7 @@ ruby_block "set-SimpleDB-Properties" do
     # We read the credentials from the same place that Priam will.
     creds_file  = "/etc/awscredential.properties"
     keys        = Hash[File.read(creds_file).split.map{|e| e.split("=") }]
-    sdb         = AWS::SimpleDB.new(
+    sdb         = Aws::SimpleDB.new(
       :access_key_id      => keys["AWSACCESSID"],
       :secret_access_key  => keys["AWSKEY"]
     )


### PR DESCRIPTION
Since the newer version of the Ruby SDK will be installed on the chef_gem step, we need
to reference Aws:: rather than the old AWS::
